### PR TITLE
fix: align compose ports, JIT URLs, and test with renumbered workspac…

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,18 +24,18 @@ services:
       - '5201:5201' # net/apex
       - '5301:5301' # org/apex
       - '5401:5401' # app/apex
-      - '5170:5170' # com/core
-      - '5171:5171' # app/core
-      - '5172:5172' # org/core
-      - '5174:5174' # app/docs
-      - '5177:5177' # com/docs
-      - '5180:5180' # org/docs
-      - '5175:5175' # app/help
-      - '5178:5178' # com/help
-      - '5181:5181' # org/help
-      - '5176:5176' # app/news
-      - '5179:5179' # com/news
-      - '5182:5182' # org/news
+      - '5102:5102' # com/core
+      - '5402:5402' # app/core
+      - '5302:5302' # org/core
+      - '5403:5403' # app/docs
+      - '5103:5103' # com/docs
+      - '5303:5303' # org/docs
+      - '5404:5404' # app/help
+      - '5104:5104' # com/help
+      - '5304:5304' # org/help
+      - '5405:5405' # app/news
+      - '5105:5105' # com/news
+      - '5305:5305' # org/news
     command: sleep infinity
     tty: true
     stdin_open: true
@@ -43,18 +43,18 @@ services:
     user: edge:group
     environment:
       - CLOUDFLARE_ENV=development
-      - JIT_APP_CORE_URL=http://app.localhost:5171
-      - JIT_APP_DOCS_URL=http://app.localhost:5174
-      - JIT_APP_HELP_URL=http://app.localhost:5175
-      - JIT_APP_NEWS_URL=http://app.localhost:5176
-      - JIT_COM_CORE_URL=http://com.localhost:5170
-      - JIT_COM_DOCS_URL=http://com.localhost:5177
-      - JIT_COM_HELP_URL=http://com.localhost:5178
-      - JIT_COM_NEWS_URL=http://com.localhost:5179
-      - JIT_ORG_CORE_URL=http://org.localhost:5172
-      - JIT_ORG_DOCS_URL=http://org.localhost:5180
-      - JIT_ORG_HELP_URL=http://org.localhost:5181
-      - JIT_ORG_NEWS_URL=http://org.localhost:5182
+      - JIT_APP_CORE_URL=http://app.localhost:5402
+      - JIT_APP_DOCS_URL=http://app.localhost:5403
+      - JIT_APP_HELP_URL=http://app.localhost:5404
+      - JIT_APP_NEWS_URL=http://app.localhost:5405
+      - JIT_COM_CORE_URL=http://com.localhost:5102
+      - JIT_COM_DOCS_URL=http://com.localhost:5103
+      - JIT_COM_HELP_URL=http://com.localhost:5104
+      - JIT_COM_NEWS_URL=http://com.localhost:5105
+      - JIT_ORG_CORE_URL=http://org.localhost:5302
+      - JIT_ORG_DOCS_URL=http://org.localhost:5303
+      - JIT_ORG_HELP_URL=http://org.localhost:5304
+      - JIT_ORG_NEWS_URL=http://org.localhost:5305
       - VITE_GIT_HOOKS=0
       - NODE_OPTIONS=--max-old-space-size=4096
     restart: unless-stopped

--- a/dev/core/package.json
+++ b/dev/core/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --port 5502",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --port 5502",
     "type": "vp exec tsc --noEmit"
   },
   "dependencies": {

--- a/shared/web/jit-url.test.ts
+++ b/shared/web/jit-url.test.ts
@@ -11,9 +11,9 @@ describe('shared/web/jit-url', () => {
   it('normalizes the workspace url', () => {
     expect(
       getJitWorkspaceUrl('APP', 'CORE', {
-        JIT_APP_CORE_URL: 'http://localhost:5171/',
+        JIT_APP_CORE_URL: 'http://localhost:5402/',
       }),
-    ).toBe('http://localhost:5171');
+    ).toBe('http://localhost:5402');
   });
 
   it('returns null when the workspace url is missing', () => {


### PR DESCRIPTION
…e ports

- Update compose.yaml port mappings from 517x/518x to new port scheme
- Update JIT_*_URL environment variables to match new ports
- Fix dev/core start script to use --port 5502 (consistent with dev script)
- Update jit-url.test.ts hardcoded port 5171 to 5402 (app/core new port)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reconfigured development environment service port mappings and corresponding environment variable URLs to use updated port ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->