### PR TITLE
[update] daily update. (re

### DIFF
--- a/app/apex/test/routes/health-route.test.ts
+++ b/app/apex/test/routes/health-route.test.ts
@@ -25,6 +25,18 @@ describe('GET /health', () => {
     expect(body).toContain('<title>UMAXICA</title>');
   });
 
+  it('returns OK when revision metadata is incomplete', async () => {
+    const response = await requestFromApp('/health', undefined, {
+      BRAND_NAME: 'UMAXICA',
+      REVISION: { id: 'test-version-id' },
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('<strong>Status:</strong> OK');
+    expect(body).toContain('test-version-id');
+  });
+
   it('applies security headers to HTML responses', async () => {
     const response = await requestFromApp('/health');
 

--- a/com/apex/test/health-route.test.ts
+++ b/com/apex/test/health-route.test.ts
@@ -24,6 +24,18 @@ describe('GET /health', () => {
     expect(body).toContain('<title>UMAXICA</title>');
   });
 
+  it('returns OK when revision metadata is incomplete', async () => {
+    const response = await requestFromComApp('/health', undefined, {
+      BRAND_NAME: 'UMAXICA',
+      REVISION: { id: 'test-version-id' },
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('<strong>Status:</strong> OK');
+    expect(body).toContain('test-version-id');
+  });
+
   it('applies security headers to the health response', async () => {
     const response = await requestFromComApp('/health');
 

--- a/shared/apex/html/health-page.ts
+++ b/shared/apex/html/health-page.ts
@@ -14,14 +14,9 @@ function escapeHtml(value: string): string {
 export function buildHealthPageHtml(
   brandName: string,
   timestampIso: string,
-  revision?: { id: string; tag: string; timestamp: string },
+  revision?: { id?: unknown; tag?: unknown; timestamp?: unknown },
 ): string {
-  const revisionValue = revision
-    ? [revision.id, revision.tag, revision.timestamp]
-        .filter((value) => value.length > 0)
-        .map(escapeHtml)
-        .join(' ')
-    : '';
+  const revisionValue = formatRevision(revision);
 
   return `<!doctype html>
 <html lang="ja">
@@ -44,6 +39,23 @@ export function buildHealthPageHtml(
     </main>
   </body>
 </html>`;
+}
+
+function formatRevision(revision?: { id?: unknown; tag?: unknown; timestamp?: unknown }): string {
+  if (!revision) {
+    return '';
+  }
+
+  return [revision.id, revision.tag, revision.timestamp]
+    .filter((value): value is string | number | boolean => {
+      if (typeof value === 'string') {
+        return value.length > 0;
+      }
+
+      return typeof value === 'number' || typeof value === 'boolean';
+    })
+    .map((value) => escapeHtml(String(value)))
+    .join(' ');
 }
 
 export function getBrandName(env?: { BRAND_NAME?: string }): string {

--- a/shared/apex/test/routes/health.test.ts
+++ b/shared/apex/test/routes/health.test.ts
@@ -68,6 +68,21 @@ describe('shared/apex/routes/health.ts', () => {
       expect(body).not.toContain('Revision Time');
     });
 
+    it('tolerates incomplete revision metadata', async () => {
+      const route = createHealthRoute();
+      const res = await route.request('/health', {}, {
+        BRAND_NAME: 'UMAXICA',
+        REVISION: {
+          id: 'df8ea12b-8219-4acd-a00e-b7ddb93568fb',
+        },
+      } as unknown as { BRAND_NAME: string });
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).toContain('<strong>Status:</strong> OK');
+      expect(body).toContain('df8ea12b-8219-4acd-a00e-b7ddb93568fb');
+    });
+
     it('ignores RAILS_API_URL and does not call external services', async () => {
       const fetchMock = vi.fn<typeof fetch>();
       vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The health check endpoint now gracefully handles incomplete revision metadata, continuing to report successful status even when revision tag or timestamp information is not available.

* **Tests**
  * Added test coverage verifying the health endpoint correctly responds with status 200 and displays OK status when revision metadata is partially provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->